### PR TITLE
SelfKeywordUsageCheck: fix false positive issues in class field declaration

### DIFF
--- a/php-checks/src/main/java/org/sonar/php/checks/SelfKeywordUsageCheck.java
+++ b/php-checks/src/main/java/org/sonar/php/checks/SelfKeywordUsageCheck.java
@@ -43,6 +43,10 @@ public class SelfKeywordUsageCheck extends SquidCheck<LexerlessGrammar> {
 
   @Override
   public void visitNode(AstNode astNode) {
+    if (astNode.getFirstAncestor(PHPGrammar.CLASS_VARIABLE_DECLARATION) != null) {
+      return;
+    }
+
     AstNode caller = astNode.getPreviousAstNode();
 
     if ("self".equals(caller.getTokenOriginalValue())) {

--- a/php-checks/src/test/java/org/sonar/php/checks/SelfKeywordUsageCheckTest.java
+++ b/php-checks/src/test/java/org/sonar/php/checks/SelfKeywordUsageCheckTest.java
@@ -33,7 +33,7 @@ public class SelfKeywordUsageCheckTest extends CheckTest {
     SourceFile file = PHPAstScanner.scanSingleFile(TestUtils.getCheckFile("SelfKeywordUsageCheck.php"), new SelfKeywordUsageCheck());
 
     checkMessagesVerifier.verify(file.getCheckMessages())
-      .next().atLine(8).withMessage("Use \"static\" keyword instead of \"self\".")
+      .next().atLine(14).withMessage("Use \"static\" keyword instead of \"self\".")
       .noMore();
   }
 

--- a/php-checks/src/test/resources/checks/SelfKeywordUsageCheck.php
+++ b/php-checks/src/test/resources/checks/SelfKeywordUsageCheck.php
@@ -2,13 +2,19 @@
 
 class A {
 
+  const CONSTANT = 0;
+
   public static $field;
 
-  public static function f() {
+  public $arr = array(
+    self::CONSTANT             // OK
+  );
+
+  public static function f1() {
     return self::$field;       // NOK
   }
 
-  public static function f() {
+  public static function f2() {
     return static::$field;     // OK
   }
 


### PR DESCRIPTION
see test file
https://github.com/sanyatuning/sonar-php/blob/0e19ed52abece8ece6e6b35d7cb6ff9ef6695e69/php-checks/src/test/resources/checks/SelfKeywordUsageCheck.php